### PR TITLE
Fix Blizzard coin icons, and use by default instead of custom.

### DIFF
--- a/ChatCleaner/modules/filters/money.lua
+++ b/ChatCleaner/modules/filters/money.lua
@@ -45,7 +45,7 @@ local CURRENT_CHAT_FRAME
 
 -- Return a coin texture string.
 local Coin = setmetatable({}, { __index = function(t,k)
-	local useBlizz = Core.db.useBlizzardCoins
+	local useBlizz = true
 	local frame = CURRENT_CHAT_FRAME or DEFAULT_CHAT_FRAME or ChatFrame1
 	local _,size = frame:GetFont()
 	size = size or 20
@@ -56,19 +56,19 @@ local Coin = setmetatable({}, { __index = function(t,k)
 	end
 	if (k == "Gold") then
 		if (useBlizz) then
-			return string_format([[|TInterface\MoneyFrame\UI-GoldIcon:%d:%d:2:0|t]], size, size)
+			return string_format([[|Tinterface/moneyframe/ui-goldicon:%d:%d:2:0|t]], size, size)
 		else
 			return string_format([[|TInterface\AddOns\%s\media\coins.tga:%d:%d:-2:0:64:64:0:32:0:32|t]], Addon, size, size)
 		end
 	elseif (k == "Silver") then
 		if (useBlizz) then
-			return string_format([[|TInterface\MoneyFrame\UI-SilverIcon:%d:%d:2:0|t]], size, size)
+			return string_format([[|Tinterface/moneyframe/ui-silvericon:%d:%d:2:0|t]], size, size)
 		else
 			return string_format([[|TInterface\AddOns\%s\media\coins.tga:%d:%d:-2:0:64:64:32:64:0:32|t]], Addon, size, size)
 		end
 	elseif (k == "Copper") then
 		if (useBlizz) then
-			return string_format([[|TInterface\MoneyFrame\UI-CopperIcon:%d:%d:2:0|t]], size, size)
+			return string_format([[|Tinterface/moneyframe/ui-coppericon:%d:%d:2:0|t]], size, size)
 		else
 			return string_format([[|TInterface\AddOns\%s\media\coins.tga:%d:%d:-2:0:64:64:0:32:32:64|t]], Addon, size, size)
 		end


### PR DESCRIPTION
- The path to the official Blizzard Icons wasn't working - when setting `useBlizz` to `true` no coin icons would show up in the chat frame when e.g. looting coins from my mailbox or selling items to vendors. I've fixed the path to the icon.
- I have also set it to use the blizzard icons by default... though I don't know if this is over-reaching, since it seems like your UI addons often use custom art as a deliberate design choice. I prefer the icons to be consistent across the UI, but understandable if it doesn't fit the vision for this addon.

I didn't want to clean up the conditionals for `useBlizz`, because while you don't have an options UI, this is something that's been added ready to be toggled by a potential menu in future? I'm not familiar enough with WoW Addons to know whether there are ways to set this value without an Addon-provided options panel.